### PR TITLE
Change text color of false answer to accessible one

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -153,7 +153,7 @@ a.link-style:hover::before {
 
 .false-text{
   /* color: #9f0500;*/
-  color: #BC4749;
+  color: white;
 }
 .truth-text{
   /* color: #194d33; */


### PR DESCRIPTION
Changing the text of a false answer from red to white, so that the user can read more clearly.